### PR TITLE
update to add role requirement

### DIFF
--- a/_index.yml
+++ b/_index.yml
@@ -17,10 +17,10 @@ indexpage:
           url: task-manage-volumes.html
     - title: Blogs & community
       links:
-       - title: NetApp Community
-         url: https://community.netapp.com/t5/Cloud-Data-Services/ct-p/CDS
-       - title: NetApp Console blog
-         url: https://cloud.netapp.com/blog
-       - title: Cloud webinars
-         url: https://cloud.netapp.com/events
+        - title: NetApp Console
+          url: https://www.netapp.com/console
+        - title: NetApp Data Services
+          url: https://www.netapp.com/data-services/
+        - title: NetApp Community
+          url: https://community.netapp.com/
           # End snippet

--- a/concept-gcnv.adoc
+++ b/concept-gcnv.adoc
@@ -17,6 +17,8 @@ Google Cloud NetApp Volumes is a fully managed, cloud-based data storage service
 
 NetApp Volumes helps to accelerate deployment times, manage your workloads and applications, and migrate workloads to the cloud while keeping the performance and features of on-premises storage.
 
+NOTE: To start working with Google Cloud NetApp Volumes, you must have the appropriate permissions and roles assigned. The required NetApp Console roles are organization admin, folder or project admin, or Google Cloud NetApp Volumes admin role. https://docs.netapp.com/us-en/console-setup-admin/reference-iam-predefined-roles.html[Learn about NetApp Console access roles for all services^].
+
 == Features
 
 * Runs enterprise apps faster and more efficiently.

--- a/task-manage-volumes.adoc
+++ b/task-manage-volumes.adoc
@@ -16,7 +16,7 @@ summary: After you set up your system, you can view your Google Cloud NetApp vol
 You can view your existing volumes and any actions you performed on them.
 
 *Required NetApp Console role*
-Organization admin, Folder or project admin, or Google Cloud NetApp Volumes admin role. https://docs.netapp.com/us-en/console-setup-admin/reference-iam-predefined-roles.html[Learn about NetApp Console access roles for all services^].
+Organization admin, folder or project admin, or Google Cloud NetApp Volumes admin role. https://docs.netapp.com/us-en/console-setup-admin/reference-iam-predefined-roles.html[Learn about NetApp Console access roles for all services^].
 
 == View a volume
 

--- a/task-set-up-gcnv.adoc
+++ b/task-set-up-gcnv.adoc
@@ -15,15 +15,14 @@ summary: The NetApp Console needs access to the Google Cloud NetApp Volumes API 
 [.lead]
 The NetApp Console needs the right permissions through a Google Cloud service account.
 
-== Set up a service account
-
-Complete the following tasks so that the NetApp Console can access your Google Cloud project:
+Complete the following tasks so that the NetApp Console can access your Google Cloud project.
 
 * If you do not already have an existing service account, create a new one.
 * Add the service account member to your project and assign it specific roles (permissions).
 * Create and download a key pair for the service account that is used to authenticate to Google.
+* Grant the IAM role in the shared project.
 
-.Steps
+== Set up a service account
 
 . In the Google Cloud console, https://console.cloud.google.com/iam-admin/serviceaccounts[go to the Service accounts page^].
 
@@ -38,7 +37,21 @@ The Google Cloud Console generates a service account ID based on this name. Edit
 
 .. To set access controls now, click *Create* and then *DONE* from the bottom of the page, and continue to the next step.
 
-. From the _IAM page_ click *Add* and fill out the fields in the _Add Members_ page:
+== Create and download a key pair
+
+. In the https://console.cloud.google.com/iam-admin/serviceaccounts[Service accounts page^], find and click the Service Account name.
+
+. From the _Service account details_ page, click *Add key* and then *Create new key*.
+
+. Select *JSON* as the key type and click *Create*.
++
+By clicking *Create* your new public/private key pair is generated and downloaded to your system. It serves as the only copy of the private key. Store this file securely because it can be used to authenticate as your service account.
+
+== Add the service account member
+
+. Log into the https://docs.netapp.com/us-en/console-setup-admin/task-logging-in.html[NetApp Console].
+. Select *Administration* and then *Identity and access*.
+. Click *Add* and fill out the fields in the _Add Members_ page:
 
 .. In the New Members field, enter the full service account ID.
 +
@@ -51,11 +64,15 @@ OR
 
 .. Click *Save*.
 
-. Click the Service Account name, and then from the _Service account details_ page, click *Add key* and then *Create new key*.
+== Shared VPC 
 
-. Select *JSON* as the key type and click *Create*.
-+
-By clicking *Create* your new public/private key pair is generated and downloaded to your system. It serves as the only copy of the private key. Store this file securely because it can be used to authenticate as your service account.
+In each additional GCP project that will use the service account, do the following:
+
+. In the _IAM page_, select the Shared VPC host project from the project dropdown menu. 
+. Click *Add Principal*. 
+. In the New principals field, enter the email address of your service account. 
+. From the Select a role dropdown, choose the Google Cloud NetApp Volumes admin role.
+. Click *Save*.
 
 For detailed steps, refer to Google Cloud documentation:
 


### PR DESCRIPTION
This pull request updates documentation related to Google Cloud NetApp Volumes, focusing on clarifying setup instructions, permissions, and improving resource links. The changes enhance clarity for users setting up and managing NetApp Volumes, especially regarding required roles, service account setup, and community resources.

**Documentation improvements and clarifications:**

* Added a note in `concept-gcnv.adoc` clearly stating the required NetApp Console roles for Google Cloud NetApp Volumes and linked to the official roles documentation.
* Clarified and standardized the description of required NetApp Console roles in `task-manage-volumes.adoc`.

**Service account setup process reorganization:**

* Reorganized and expanded the service account setup instructions in `task-set-up-gcnv.adoc`, breaking down the process into clearer steps: creating the service account, downloading a key pair, adding the service account member, and granting IAM roles in shared projects. [[1]](diffhunk://#diff-1ee27209a3419fe3971b18d17ca854b1c462541de1ca3e46e828f514c3598271L18-R25) [[2]](diffhunk://#diff-1ee27209a3419fe3971b18d17ca854b1c462541de1ca3e46e828f514c3598271L41-R54) [[3]](diffhunk://#diff-1ee27209a3419fe3971b18d17ca854b1c462541de1ca3e46e828f514c3598271L54-R75)

**Resource and community links update:**

* Updated and expanded the "Blogs & community" section in `_index.yml` to include new links to the NetApp Console and NetApp Data Services, and updated the NetApp Community link.