### PR TITLE
bluexpdoc-996 release notes autogen

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -5,6 +5,8 @@ settings:
   prod:
     pdf_enabled: true
     harmony_enabled: true
+    release_notes_autogen:
+      release_notes_repo: console-relnotes
   rss_page: "whats-new.html"
 sidebar:
   entries:

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -15,14 +15,10 @@ summary: Learn what's new with Google Cloud NetApp Volumes support in NetApp Con
 [.lead]
 Learn what's new with Google Cloud NetApp Volumes support in NetApp Console.
 
-// tag::whats-new[]
 == 06 October 2025
 
 include::_whatsnew/2025-10-06.adoc[]
-// end::whats-new[]
 
-// tag::whats-new[]
 == 21 July 2025
 
 include::_whatsnew/2025-07-14.adoc[]
-// end::whats-new[]


### PR DESCRIPTION
This pull request introduces a new configuration for release notes automation and cleans up the formatting of the "What's New" documentation. The most important changes are grouped below:

Release notes automation:

* Added a new `release_notes_autogen` section to the `prod` settings in `project.yml`, specifying `console-relnotes` as the repository for automated release notes.

Documentation formatting:

* Removed redundant comment tags (`// tag::whats-new[]` and `// end::whats-new[]`) from the `whats-new.adoc` file to simplify the structure and improve readability.