### PR TITLE
Hot fixes for github issues

### DIFF
--- a/task-create-working-env.adoc
+++ b/task-create-working-env.adoc
@@ -38,7 +38,7 @@ You must have the following information available when adding a subscription for
 . Provide information about your NetApp Volumes subscription:
 
 .. Enter the system name you want to use.
-.. Paste the associated Google service account email address: credentials-sa@wf-production-netapp.iam.gserviceaccount.com.
+.. Paste the associated Google service account email address. For details, see link:task-set-up-gcnv.html[Set up a service account].
 .. Select *Apply credentials* to retrieve the project name and region.
 .. From *Project name*, select the name of your Google Cloud project.
 .. From *Region*, select the region where you want to create the system. The region must be one of the supported regions for Google Cloud NetApp Volumes.

--- a/task-set-up-gcnv.adoc
+++ b/task-set-up-gcnv.adoc
@@ -38,6 +38,8 @@ The Google Cloud Console generates a service account ID based on this name. Edit
 .. From the Role list, select the *Google Cloud NetApp Volumes admin* or *Google Cloud NetApp viewer* role. 
 .. Select *Continue*.
 .. Grant impersonation access to this service account: credentials-sa@wf-production-netapp.iam.gserviceaccount.com. For details, see https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#sa-credentials-jwt[Create a self-signed JSON Web Token (JWT)^].
++
+The service account owned by NetApp is used to request a short-lived access token that lets you act as that service account without needing access to its private key.
 .. Click *DONE* at the bottom of the page, and continue to the next step.
 
 == Shared VPC 


### PR DESCRIPTION
This pull request updates documentation related to setting up and using service accounts for Google Cloud NetApp Volumes. The main focus is to clarify instructions and provide additional context about service account usage.

Documentation improvements:

* Updated instructions in `task-create-working-env.adoc` to reference the service account setup documentation instead of providing a hardcoded email address, making the process clearer and more maintainable.
* Added an explanatory note in `task-set-up-gcnv.adoc` describing how the NetApp-owned service account is used to request short-lived access tokens, improving user understanding of the authentication process.