### PR TITLE
Git issue 20

### DIFF
--- a/task-set-up-gcnv.adoc
+++ b/task-set-up-gcnv.adoc
@@ -62,7 +62,7 @@ NOTE: For staging environments, use `credentials-sa@wf-staging-netapp.iam.gservi
 
 .. Click *DONE* at the bottom of the page, and continue to the next step.
 
-NOTE: Google Cloud project permissions changes will take effect after a couple of minutes.
+Google Cloud project permissions changes will take effect after a couple of minutes.
 
 == Shared VPC 
 

--- a/task-set-up-gcnv.adoc
+++ b/task-set-up-gcnv.adoc
@@ -25,6 +25,8 @@ NOTE: You can use the Google Cloud console or the gcloud CLI for these tasks. To
 
 == Set up a service account
 
+Note: Google Cloud project permissions changes might take a couple of minutes to take effect.
+
 . In the Google Cloud console, https://console.cloud.google.com/iam-admin/serviceaccounts[go to the Service accounts page^].
 
 . Click *Select a project*, choose your project, and click *Open*.
@@ -61,8 +63,6 @@ gcloud iam service-accounts add-iam-policy-binding <YOUR_SA_EMAIL> --member="ser
 NOTE: For staging environments, use `credentials-sa@wf-staging-netapp.iam.gserviceaccount.com` instead of the production service account. Replace the `--member` parameter value in the command above with `serviceAccount:credentials-sa@wf-staging-netapp.iam.gserviceaccount.com`.
 
 .. Click *DONE* at the bottom of the page, and continue to the next step.
-
-Google Cloud project permissions changes will take effect after a couple of minutes.
 
 == Shared VPC 
 

--- a/task-set-up-gcnv.adoc
+++ b/task-set-up-gcnv.adoc
@@ -37,7 +37,7 @@ NOTE: You can use the Google Cloud console or the gcloud CLI for these tasks. To
 The Google Cloud Console generates a service account ID based on this name. Edit the ID if necessary - you cannot change the ID later.
 
 .. Click *Create and continue*.
-.. From the Role list, select the *Google Cloud NetApp Volumes admin* or *Google Cloud NetApp viewer* role. 
+.. From the Role list, select the *Google Cloud NetApp Volumes Admin* or *Google Cloud NetApp Volumes Viewer* role. 
 .. Select *Continue*.
 +
 Alternatively, you can assign the role using the gcloud CLI:
@@ -57,12 +57,16 @@ Alternatively, you can grant impersonation access using the gcloud CLI:
 ----
 gcloud iam service-accounts add-iam-policy-binding <YOUR_SA_EMAIL> --member="serviceAccount:credentials-sa@wf-production-netapp.iam.gserviceaccount.com" --role="roles/iam.serviceAccountTokenCreator" --project=<YOUR_PROJECT_ID>
 ----
++
+NOTE: For staging environments, use `credentials-sa@wf-staging-netapp.iam.gserviceaccount.com` instead of the production service account. Replace the `--member` parameter value in the command above with `serviceAccount:credentials-sa@wf-staging-netapp.iam.gserviceaccount.com`.
 
 .. Click *DONE* at the bottom of the page, and continue to the next step.
 
+NOTE: Google Cloud project permissions changes will take effect after a couple of minutes.
+
 == Shared VPC 
 
-In each additional GCP project that will use the service account, do the following:
+In each additional Google Cloud project that will use the service account, do the following:
 
 . In the _IAM page_, select the Shared VPC host project from the project dropdown menu. 
 . Click *Add Principal*. 

--- a/task-set-up-gcnv.adoc
+++ b/task-set-up-gcnv.adoc
@@ -25,7 +25,7 @@ NOTE: You can use the Google Cloud console or the gcloud CLI for these tasks. To
 
 == Set up a service account
 
-Note: Google Cloud project permissions changes might take a couple of minutes to take effect.
+NOTE: Google Cloud project permissions changes might take a couple of minutes to take effect.
 
 . In the Google Cloud console, https://console.cloud.google.com/iam-admin/serviceaccounts[go to the Service accounts page^].
 


### PR DESCRIPTION
This pull request makes several improvements to the `task-set-up-gcnv.adoc` documentation to clarify instructions and improve accuracy, especially around setting up service accounts and assigning roles. The most important changes are:

**Documentation clarity and accuracy:**

* Added a note to inform users that Google Cloud project permission changes may take a couple of minutes to take effect, helping to set expectations during setup.
* Corrected the role names in the instructions to use the proper capitalization: *Google Cloud NetApp Volumes Admin* and *Google Cloud NetApp Volumes Viewer*.
* Clarified that in staging environments, users should use the staging service account email when granting impersonation access, and provided explicit instructions for replacing the `--member` parameter.
* Updated terminology for consistency, changing "GCP project" to "Google Cloud project".